### PR TITLE
Catch network exceptions and return None instead of -1000

### DIFF
--- a/connection_request.py
+++ b/connection_request.py
@@ -54,9 +54,13 @@ class ConnectionRequest(Connection):
             warnings.filterwarnings("ignore", category=InsecureRequestWarning)
             with requests.sessions.Session() as session:
                 self.logger.info(self._params)
-                resp = session.request(**self._params)
-                self.logger.info("Command executed with code: {}".format(resp.status_code))
-        
+                try:
+                    resp = session.request(**self._params)
+                    self.logger.info("Command executed with code: {}".format(resp.status_code))
+                except (requests.exceptions.ConnectionError, OSError):
+                    # OSError is returned when there is no route to the host
+                    resp = None
+
         if resp is not None and resp.ok:
             try:
                 j = resp.json()

--- a/properties.py
+++ b/properties.py
@@ -286,7 +286,7 @@ class NumericOperation(DeviceOperation):
         try:
             f = float(self._value)
         except:
-            f = -1000 
+            f = None
         return f
 
     @property


### PR DESCRIPTION
I've been testing this for 48 hours and I think it works well. Once in a while I get "Connection refused" by the controller, but I think the timeout has significantly improved the component's operation.

I've also replaced the `-1000` value returned for inaccessible properties, because the correct one should be `None`. This should normally set the value to `unavailable` in the front end, which is more desirable than -1000. -1000 destroys the pretty graphs 😉 