### PR TITLE
Temprange fix

### DIFF
--- a/custom_components/climate_ip/climate.py
+++ b/custom_components/climate_ip/climate.py
@@ -68,8 +68,8 @@ REQUIREMENTS = ['requests>=2.21.0', 'xmljson>=0.2.0']
 
 CLIMATE_IP_DATA = 'climate_ip_data'
 ENTITIES = 'entities'
-DEFAULT_CLIMATE_IP_TEMP_MIN = 16
-DEFAULT_CLIMATE_IP_TEMP_MAX = 32
+DEFAULT_CLIMATE_IP_TEMP_MIN = 8
+DEFAULT_CLIMATE_IP_TEMP_MAX = 30
 DEFAULT_UPDATE_DELAY = 1.5
 SERVICE_SET_CUSTOM_OPERATION = 'climate_ip_set_property'
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/climate_ip/samsung_2878.yaml
+++ b/custom_components/climate_ip/samsung_2878.yaml
@@ -96,8 +96,8 @@ device:
       validation_template: '{% if "AC_FUN_DIRECTION" in device_state %}valid{% endif %}'
     temperature:
       type: number
-      min: 16
-      max: 32
+      min: 8
+      max: 30
       status_template: '{% for key, value in device_state.items() %}{% if key == "AC_FUN_TEMPSET" %}{{value}}{% endif %}{% endfor %}'
       connection_template: '<Request Type="DeviceControl"><Control CommandID="AC_FUN_TEMPSET" DUID="{{duid}}"><Attr ID="AC_FUN_TEMPSET" Value="{{value}}" /></Control></Request>'
   attributes:
@@ -106,7 +106,7 @@ device:
       status_template: '{% for key, value in device_state.items() %}{% if key == "AC_FUN_TEMPNOW" %}{{value}}{% endif %}{% endfor %}'
     min_temp:
       type: number
-      status_template: '16'
+      status_template: '8'
     max_temp:
       type: number
-      status_template: '32'
+      status_template: '30'

--- a/custom_components/climate_ip/samsungrac.yaml
+++ b/custom_components/climate_ip/samsungrac.yaml
@@ -124,8 +124,8 @@ device:
       type: number
       connection:
         params: { method: 'PUT', url: 'https://__CLIMATE_IP_HOST__:8888/devices/0/temperatures/0' }
-      min: 16
-      max: 32
+      min: 8
+      max: 30
       status_template: '{{ device_state.Devices.0.Temperatures.0.desired | int }}'
       connection_template: '{ "json": { "desired": {{ value | int }} } }'
       unit_template: '{{ device_state.Devices.0.Temperatures.0.unit }}'
@@ -136,9 +136,9 @@ device:
       unit_template: '{{ device_state.Devices.0.Temperatures.0.unit }}'
     min_temp:
       type: number
-      status_template: '16'
+      status_template: '8'
       unit_template: '{{ device_state.Devices.0.Temperatures.0.unit }}'
     max_temp:
       type: number
-      status_template: '32'
+      status_template: '30'
       unit_template: '{{ device_state.Devices.0.Temperatures.0.unit }}'


### PR DESCRIPTION
Fix for temperature range. Samsung AC support temps from 8-30 degrees. Tested on RAC and 2878. (I have both)